### PR TITLE
Use qdb instead of miniredis test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ distclean: clean
 	@make --no-print-directory --quiet -C extern/redis-2.8.13 clean
 
 gotest:
-	go test ./pkg/... ./cmd/... -race
+	go test -tags 'all' ./pkg/... ./cmd/... -race -cover

--- a/cmd/agent/check.go
+++ b/cmd/agent/check.go
@@ -111,7 +111,7 @@ func loadSavedProcs() error {
 				log.Warningf("we need proc %s, but got %s", id, p.ID)
 				continue
 			}
-			// todo bind after start func for different type
+			// TODO: bind after start func for different type
 			if err := bindProcHandler(p); err != nil {
 				log.Errorf("bind proc %s err %v, skip", p.Cmd, err)
 				continue
@@ -120,7 +120,7 @@ func loadSavedProcs() error {
 		}
 	}
 
-	//todo remove unnecessary old logs
+	// TODO: remove unnecessary old logs
 	clearOldProcsFiles(dataDir)
 	clearOldProcsFiles(logDir)
 

--- a/pkg/models/action_test.go
+++ b/pkg/models/action_test.go
@@ -8,34 +8,33 @@ import (
 	"fmt"
 	"path"
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/reborndb/reborn/pkg/utils"
 
-	"github.com/juju/errors"
 	log "github.com/ngaut/logging"
 	"github.com/ngaut/zkhelper"
-)
-
-var (
-	productName = "unit_test"
+	. "gopkg.in/check.v1"
 )
 
 func waitForProxyMarkOffline(coordConn zkhelper.Conn, proxyName string) {
 	_, _, c, _ := coordConn.GetW(path.Join(GetProxyPath(productName), proxyName))
+
 	<-c
+
+	// test action need response, if proxy not responsed, then marked offline
 	info, _ := GetProxyInfo(coordConn, productName, proxyName)
 	if info.State == PROXY_STATE_MARK_OFFLINE {
 		SetProxyStatus(coordConn, productName, proxyName, PROXY_STATE_OFFLINE)
 	}
 }
 
-func TestProxyOfflineInWaitActionReceiver(t *testing.T) {
-	log.Info("test proxy offline when waiting action response")
+func (s *testModelSuite) TestProxyOfflineInWaitActionReceiver(c *C) {
+	log.Info("[TestProxyOfflineInWaitActionReceiver][start]")
 	fakeCoordConn := zkhelper.NewConn()
 
-	for i := 1; i <= 4; i++ {
+	proxyNum := 4
+	for i := 1; i <= proxyNum; i++ {
 		CreateProxyInfo(fakeCoordConn, productName, &ProxyInfo{
 			ID:    strconv.Itoa(i),
 			State: PROXY_STATE_ONLINE,
@@ -44,81 +43,77 @@ func TestProxyOfflineInWaitActionReceiver(t *testing.T) {
 	}
 
 	lst, _ := ProxyList(fakeCoordConn, productName, nil)
-	if len(lst) != 4 {
-		t.Error("create proxy info error")
-	}
+	c.Assert(len(lst), Equals, proxyNum)
+
 	go func() {
 		time.Sleep(500 * time.Millisecond)
 		actionPath := path.Join(GetActionResponsePath(productName), fakeCoordConn.Seq2Str(1))
-		//create test response for proxy 4, means proxy 1,2,3 are timeout
+		// create test response for proxy 4, means proxy 1,2,3 are timeout
 		fakeCoordConn.Create(path.Join(actionPath, "4"), nil,
 			0, zkhelper.DefaultFileACLs())
 	}()
 
 	err := NewActionWithTimeout(fakeCoordConn, productName, ACTION_TYPE_SLOT_CHANGED, nil, "desc", true, 3*1000)
-	if err != nil && err.Error() != ErrReceiverTimeout.Error() {
-		t.Error(errors.ErrorStack(err))
+	if c.Check(err, NotNil) {
+		c.Assert(err.Error(), Equals, ErrReceiverTimeout.Error())
 	}
 
-	for i := 1; i <= 3; i++ {
-		if info, _ := GetProxyInfo(fakeCoordConn, productName, strconv.Itoa(i)); info.State != PROXY_STATE_OFFLINE {
-			t.Error("shutdown offline proxy error")
-		}
+	for i := 1; i <= proxyNum-1; i++ {
+		info, _ := GetProxyInfo(fakeCoordConn, productName, strconv.Itoa(i))
+		c.Assert(info.State, Equals, PROXY_STATE_OFFLINE)
 	}
+
+	fakeCoordConn.Close()
+	log.Info("[TestProxyOfflineInWaitActionReceiver][end]")
 }
 
-func TestNewAction(t *testing.T) {
+func (s *testModelSuite) TestNewAction(c *C) {
+	log.Info("[TestNewAction][start]")
 	fakeCoordConn := zkhelper.NewConn()
+
 	err := NewAction(fakeCoordConn, productName, ACTION_TYPE_SLOT_CHANGED, nil, "desc", false)
-	if err != nil {
-		t.Error(errors.ErrorStack(err))
-	}
+	c.Assert(err, IsNil)
+
 	prefix := GetWatchActionPath(productName)
-	if exist, _, err := fakeCoordConn.Exists(prefix); !exist {
-		t.Error(errors.ErrorStack(err))
-	}
+	exist, _, err := fakeCoordConn.Exists(prefix)
+	c.Assert(exist, Equals, true)
+	c.Assert(err, IsNil)
 
-	//test if response node exists
+	// test if response node exists
 	d, _, err := fakeCoordConn.Get(prefix + "/0000000001")
-	if err != nil {
-		t.Error(errors.ErrorStack(err))
-	}
+	c.Assert(err, IsNil)
 
-	//test get action data
+	// test get action data
 	d, _, err = fakeCoordConn.Get(GetActionResponsePath(productName) + "/0000000001")
-	if err != nil {
-		t.Error(errors.ErrorStack(err))
-	}
+	c.Assert(err, IsNil)
 
 	var action Action
 	json.Unmarshal(d, &action)
-	if action.Desc != "desc" || action.Type != ACTION_TYPE_SLOT_CHANGED {
-		t.Error("create action error")
-	}
+	c.Assert(action.Desc, Equals, "desc")
+	c.Assert(action.Type, Equals, ACTION_TYPE_SLOT_CHANGED)
+
+	fakeCoordConn.Close()
+	log.Info("[TestNewAction][end]")
 }
 
-func TestForceRemoveLock(t *testing.T) {
+func (s *testModelSuite) TestForceRemoveLock(c *C) {
+	log.Info("[TestForceRemoveLock][start]")
 	fakeCoordConn := zkhelper.NewConn()
+
 	zkLock := utils.GetCoordLock(fakeCoordConn, productName)
-	if zkLock == nil {
-		t.Error("create lock error")
-	}
+	c.Assert(zkLock, NotNil)
 
 	zkLock.Lock("force remove lock")
 	coordPath := fmt.Sprintf("/zk/reborn/db_%s/LOCK", productName)
 	children, _, err := fakeCoordConn.Children(coordPath)
-	if err != nil {
-		t.Error(err)
-	}
-	if len(children) == 0 {
-		t.Error("create lock error")
-	}
+	c.Assert(err, IsNil)
+	c.Assert(len(children), Not(Equals), 0)
+
 	ForceRemoveLock(fakeCoordConn, productName)
 	children, _, err = fakeCoordConn.Children(coordPath)
-	if err != nil {
-		t.Error(err)
-	}
-	if len(children) != 0 {
-		t.Error("remove lock error")
-	}
+	c.Assert(err, IsNil)
+	c.Assert(len(children), Equals, 0)
+
+	fakeCoordConn.Close()
+	log.Info("[TestForceRemoveLock][end]")
 }

--- a/pkg/models/proxy.go
+++ b/pkg/models/proxy.go
@@ -33,6 +33,13 @@ type ProxyInfo struct {
 	StartAt      string `json:"start_at"`
 }
 
+func (p *ProxyInfo) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("[ProxyInfo](%+v)", *p)
+}
+
 func (p *ProxyInfo) Ops() (int64, error) {
 	m, err := p.DebugVars()
 	if err != nil {
@@ -72,6 +79,7 @@ func CreateProxyInfo(coordConn zkhelper.Conn, productName string, pi *ProxyInfo)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
+
 	dir := GetProxyPath(productName)
 	zkhelper.CreateRecursive(coordConn, dir, "", 0, zkhelper.DefaultDirACLs())
 	return coordConn.Create(path.Join(dir, pi.ID), data, zk.FlagEphemeral, zkhelper.DefaultFileACLs())
@@ -99,6 +107,7 @@ func ProxyList(coordConn zkhelper.Conn, productName string, filter func(*ProxyIn
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+
 		if filter == nil || filter(pi) == true {
 			ret = append(ret, *pi)
 		}
@@ -116,10 +125,12 @@ func GetFenceProxyMap(coordConn zkhelper.Conn, productName string) (map[string]b
 			return nil, err
 		}
 	}
+
 	m := make(map[string]bool, len(children))
 	for _, fenceNode := range children {
 		m[fenceNode] = true
 	}
+
 	return m, nil
 }
 
@@ -141,6 +152,7 @@ func SetProxyStatus(coordConn zkhelper.Conn, productName string, proxyName strin
 		if err != nil {
 			return errors.Trace(err)
 		}
+
 		for _, slot := range slots {
 			if slot.State.Status != SLOT_STATUS_ONLINE {
 				return errors.Errorf("slot %v is not online", slot)
@@ -168,7 +180,9 @@ func SetProxyStatus(coordConn zkhelper.Conn, productName string, proxyName strin
 			} else if err != nil {
 				return errors.Trace(err)
 			}
+
 			<-c
+
 			info, err := GetProxyInfo(coordConn, productName, proxyName)
 			log.Info("mark_offline, check proxy status:", proxyName, info, err)
 			if zkhelper.ZkErrorEqual(err, zk.ErrNoNode) {
@@ -177,6 +191,7 @@ func SetProxyStatus(coordConn zkhelper.Conn, productName string, proxyName strin
 			} else if err != nil {
 				return errors.Trace(err)
 			}
+
 			if info.State == PROXY_STATE_OFFLINE {
 				log.Info("proxy:", proxyName, "offline success!")
 				return nil

--- a/pkg/models/proxy_test.go
+++ b/pkg/models/proxy_test.go
@@ -4,7 +4,14 @@
 package models
 
 import (
+	"fmt"
+	"os"
+	"path"
 	"testing"
+
+	"github.com/reborndb/qdb/pkg/engine/rocksdb"
+	"github.com/reborndb/qdb/pkg/service"
+	"github.com/reborndb/qdb/pkg/store"
 
 	log "github.com/ngaut/logging"
 	"github.com/ngaut/zkhelper"
@@ -21,13 +28,66 @@ func TestT(t *testing.T) {
 
 var _ = Suite(&testModelSuite{})
 
+type testServer struct {
+	addr  string
+	store *store.Store
+}
+
+func (s *testServer) Close() {
+	if s.store != nil {
+		s.store.Close()
+		s.store = nil
+	}
+}
+
 type testModelSuite struct {
+	s1 *testServer
+	s2 *testServer
 }
 
 func (s *testModelSuite) SetUpSuite(c *C) {
+	s.s1 = s.testCreateServer(c, 26380)
+	c.Assert(s.s1, NotNil)
+
+	s.s2 = s.testCreateServer(c, 26381)
+	c.Assert(s.s2, NotNil)
 }
 
 func (s *testModelSuite) TearDownSuite(c *C) {
+	if s.s1 != nil {
+		s.s1.Close()
+	}
+
+	if s.s2 != nil {
+		s.s2.Close()
+	}
+}
+
+func (s *testModelSuite) testCreateServer(c *C, port int) *testServer {
+	base := fmt.Sprintf("/tmp/test_reborn/test_proxy_models/%d", port)
+	err := os.RemoveAll(base)
+	c.Assert(err, IsNil)
+
+	err = os.MkdirAll(base, 0700)
+	c.Assert(err, IsNil)
+
+	conf := rocksdb.NewDefaultConfig()
+	testdb, err := rocksdb.Open(path.Join(base, "db"), conf, false)
+	c.Assert(err, IsNil)
+
+	cfg := service.NewDefaultConfig()
+	cfg.Listen = fmt.Sprintf("127.0.0.1:%d", port)
+	cfg.DumpPath = path.Join(base, "rdb.dump")
+	cfg.SyncFilePath = path.Join(base, "sync.pipe")
+
+	store := store.New(testdb)
+	go service.Serve(cfg, store)
+
+	ss := new(testServer)
+	ss.addr = cfg.Listen
+	ss.store = store
+
+	return ss
 }
 
 func (s *testModelSuite) TestProxy(c *C) {

--- a/pkg/models/proxy_test.go
+++ b/pkg/models/proxy_test.go
@@ -6,58 +6,66 @@ package models
 import (
 	"testing"
 
+	log "github.com/ngaut/logging"
 	"github.com/ngaut/zkhelper"
+	. "gopkg.in/check.v1"
 )
 
-func TestProxy(t *testing.T) {
+var (
+	productName = "unit_test"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testModelSuite{})
+
+type testModelSuite struct {
+}
+
+func (s *testModelSuite) SetUpSuite(c *C) {
+}
+
+func (s *testModelSuite) TearDownSuite(c *C) {
+}
+
+func (s *testModelSuite) TestProxy(c *C) {
+	log.Info("[TestProxy][start]")
 	fakeCoordConn := zkhelper.NewConn()
+
 	path := GetSlotBasePath(productName)
 	children, _, _ := fakeCoordConn.Children(path)
-	if len(children) != 0 {
-		t.Error("slot is no empty")
-	}
+	c.Assert(len(children), Equals, 0)
 
 	g := NewServerGroup(productName, 1)
 	g.Create(fakeCoordConn)
 
 	// test create new group
 	_, err := ServerGroups(fakeCoordConn, productName)
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
 
 	ok, err := g.Exists(fakeCoordConn)
-	if !ok || err != nil {
-		t.Error("create group error")
-	}
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, true)
 
 	s1 := NewServer(SERVER_TYPE_MASTER, "localhost:1111")
 
 	g.AddServer(fakeCoordConn, s1)
 
 	err = InitSlotSet(fakeCoordConn, productName, 1024)
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
 
-	children, _, _ = fakeCoordConn.Children(path)
-	if len(children) != 1024 {
-		t.Error("init slots error")
-	}
+	children, _, err = fakeCoordConn.Children(path)
+	c.Assert(err, IsNil)
+	c.Assert(len(children), Equals, 1024)
 
-	s, err := GetSlot(fakeCoordConn, productName, 1)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if s.GroupId != -1 {
-		t.Error("init slots error")
-	}
+	sl, err := GetSlot(fakeCoordConn, productName, 1)
+	c.Assert(err, IsNil)
+	c.Assert(sl.GroupId, Equals, -1)
 
 	err = SetSlotRange(fakeCoordConn, productName, 0, 1023, 1, SLOT_STATUS_ONLINE)
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
 
 	pi := &ProxyInfo{
 		ID:    "proxy_1",
@@ -66,30 +74,20 @@ func TestProxy(t *testing.T) {
 	}
 
 	_, err = CreateProxyInfo(fakeCoordConn, productName, pi)
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
 
 	ps, err := ProxyList(fakeCoordConn, productName, nil)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if len(ps) != 1 || ps[0].ID != "proxy_1" {
-		t.Error("create proxy error")
-	}
+	c.Assert(err, IsNil)
+	c.Assert(len(ps), Equals, 1)
+	c.Assert(ps[0].ID, Equals, "proxy_1")
 
 	err = SetProxyStatus(fakeCoordConn, productName, pi.ID, PROXY_STATE_ONLINE)
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
 
 	p, err := GetProxyInfo(fakeCoordConn, productName, pi.ID)
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
+	c.Assert(p.State, Equals, PROXY_STATE_ONLINE)
 
-	if p.State != PROXY_STATE_ONLINE {
-		t.Error("change status error")
-	}
+	fakeCoordConn.Close()
+	log.Info("[TestProxy][end]")
 }

--- a/pkg/models/server_group.go
+++ b/pkg/models/server_group.go
@@ -200,7 +200,7 @@ func (sg *ServerGroup) RemoveServer(coordConn zkhelper.Conn, addr string) error 
 	return errors.Trace(err)
 }
 
-func (sg *ServerGroup) Promote(conn zkhelper.Conn, addr string) error {
+func (sg *ServerGroup) Promote(conn zkhelper.Conn, addr string, auth string) error {
 	var s *Server
 	exists := false
 	for i := 0; i < len(sg.Servers); i++ {
@@ -229,8 +229,7 @@ func (sg *ServerGroup) Promote(conn zkhelper.Conn, addr string) error {
 	// old master may be nil
 	if master != nil {
 		master.Type = SERVER_TYPE_OFFLINE
-
-		err = sg.AddServer(conn, master)
+		err = sg.AddServer(conn, master, auth)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -238,7 +237,7 @@ func (sg *ServerGroup) Promote(conn zkhelper.Conn, addr string) error {
 
 	// promote new server to master
 	s.Type = SERVER_TYPE_MASTER
-	err = self.AddServer(conn, s, auth)
+	err = sg.AddServer(conn, s, auth)
 	return errors.Trace(err)
 }
 
@@ -276,8 +275,8 @@ func (sg *ServerGroup) Exists(coordConn zkhelper.Conn) (bool, error) {
 
 var ErrNodeExists = errors.New("node already exists")
 
-func (self *ServerGroup) AddServer(coordConn zkhelper.Conn, s *Server, auth string) error {
-	s.GroupId = self.Id
+func (sg *ServerGroup) AddServer(coordConn zkhelper.Conn, s *Server, auth string) error {
+	s.GroupId = sg.Id
 
 	servers, err := sg.GetServers(coordConn)
 	if err != nil {

--- a/pkg/models/server_group_test.go
+++ b/pkg/models/server_group_test.go
@@ -63,7 +63,7 @@ func (s *testModelSuite) TestServerGroup(c *C) {
 	g.AddServer(fakeCoordConn, s2, auth)
 	c.Assert(len(g.Servers), Equals, 2)
 
-	err = g.Promote(fakeCoordConn, s2.Addr)
+	err = g.Promote(fakeCoordConn, s2.Addr, auth)
 	c.Assert(err, IsNil)
 
 	m, err := g.Master(fakeCoordConn)

--- a/pkg/models/server_group_test.go
+++ b/pkg/models/server_group_test.go
@@ -39,7 +39,7 @@ func (s *testModelSuite) runFakeRedisSrv(addr string) {
 	}
 }
 
-// Todo
+// TODO
 // Use qdb later
 func (s *testModelSuite) resetEnv() {
 	conn = zkhelper.NewConn()

--- a/pkg/models/server_group_test.go
+++ b/pkg/models/server_group_test.go
@@ -7,11 +7,11 @@ import (
 	"bufio"
 	"net"
 	"sync"
-	"testing"
 	"time"
 
-	"github.com/juju/errors"
+	log "github.com/ngaut/logging"
 	"github.com/ngaut/zkhelper"
+	. "gopkg.in/check.v1"
 )
 
 var (
@@ -19,11 +19,12 @@ var (
 	conn zkhelper.Conn
 )
 
-func runFakeRedisSrv(addr string) {
+func (s *testModelSuite) runFakeRedisSrv(addr string) {
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
 		panic(err)
 	}
+
 	for {
 		c, err := l.Accept()
 		if err != nil {
@@ -38,107 +39,76 @@ func runFakeRedisSrv(addr string) {
 	}
 }
 
-func resetEnv() {
+// Todo
+// Use qdb later
+func (s *testModelSuite) resetEnv() {
 	conn = zkhelper.NewConn()
 	once.Do(func() {
-		go runFakeRedisSrv("127.0.0.1:1111")
-		go runFakeRedisSrv("127.0.0.1:2222")
+		go s.runFakeRedisSrv("127.0.0.1:1111")
+		go s.runFakeRedisSrv("127.0.0.1:2222")
 		time.Sleep(1 * time.Second)
 	})
 }
 
-func TestAddSlaveToEmptyGroup(t *testing.T) {
-	resetEnv()
+func (s *testModelSuite) TestAddSlaveToEmptyGroup(c *C) {
+	log.Info("[TestAddSlaveToEmptyGroup][start]")
+	s.resetEnv()
+
 	g := NewServerGroup(productName, 1)
 	g.Create(conn)
 
 	s1 := NewServer(SERVER_TYPE_SLAVE, "127.0.0.1:1111")
 	err := g.AddServer(conn, s1)
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
+	c.Assert(g.Servers[0].Type, Equals, SERVER_TYPE_MASTER)
 
-	if g.Servers[0].Type != SERVER_TYPE_MASTER {
-		t.Error("add a slave to an empty group, this server should become master")
-	}
+	log.Info("[TestAddSlaveToEmptyGroup][end]")
 }
 
-func TestServerGroup(t *testing.T) {
-	resetEnv()
+func (s *testModelSuite) TestServerGroup(c *C) {
+	log.Info("[TestServerGroup][start]")
+	s.resetEnv()
 
 	g := NewServerGroup(productName, 1)
 	g.Create(conn)
 
 	// test create new group
 	groups, err := ServerGroups(conn, productName)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	if len(groups) == 0 {
-		t.Error("create group error")
-		return
-	}
+	c.Assert(err, IsNil)
+	c.Assert(len(groups), Not(Equals), 0)
 
 	ok, err := g.Exists(conn)
-	if !ok || err != nil {
-		t.Error("create group error")
-		return
-	}
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, true)
 
 	gg, err := GetGroup(conn, productName, 1)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	if gg == nil || gg.Id != g.Id {
-		t.Error("get group error")
-		return
-	}
+	c.Assert(err, IsNil)
+	c.Assert(gg, NotNil)
+	c.Assert(gg.Id, Equals, g.Id)
 
 	s1 := NewServer(SERVER_TYPE_MASTER, "127.0.0.1:1111")
 	s2 := NewServer(SERVER_TYPE_MASTER, "127.0.0.1:2222")
 
 	err = g.AddServer(conn, s1)
+	c.Assert(err, IsNil)
 
 	servers, err := g.GetServers(conn)
-	if err != nil {
-		t.Error("add server error")
-		return
-	}
-	if len(servers) != 1 {
-		t.Error("add server error", len(servers))
-		return
-	}
+	c.Assert(err, IsNil)
+	c.Assert(len(servers), Equals, 1)
 
 	g.AddServer(conn, s2)
-	if len(g.Servers) != 1 {
-		t.Error("add server error, cannot add 2 masters")
-		return
-	}
+	c.Assert(len(g.Servers), Equals, 1)
 
 	s2.Type = SERVER_TYPE_SLAVE
 	g.AddServer(conn, s2)
-	if len(g.Servers) != 2 {
-		t.Error("add slave server error")
-		return
-	}
+	c.Assert(len(g.Servers), Equals, 2)
 
-	if err := g.Promote(conn, s2.Addr); err != nil {
-		t.Error(errors.ErrorStack(err))
-		return
-	}
+	err = g.Promote(conn, s2.Addr)
+	c.Assert(err, IsNil)
 
-	s, err := g.Master(conn)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	m, err := g.Master(conn)
+	c.Assert(err, IsNil)
+	c.Assert(m.Addr, Equals, s2.Addr)
 
-	if s.Addr != s2.Addr {
-		t.Error("promote error", s, s1)
-		return
-	}
+	log.Info("[TestServerGroup][stop]")
 }

--- a/pkg/models/server_group_test.go
+++ b/pkg/models/server_group_test.go
@@ -4,111 +4,72 @@
 package models
 
 import (
-	"bufio"
-	"net"
-	"sync"
-	"time"
-
 	log "github.com/ngaut/logging"
 	"github.com/ngaut/zkhelper"
 	. "gopkg.in/check.v1"
 )
 
-var (
-	once sync.Once
-	conn zkhelper.Conn
-)
-
-func (s *testModelSuite) runFakeRedisSrv(addr string) {
-	l, err := net.Listen("tcp", addr)
-	if err != nil {
-		panic(err)
-	}
-
-	for {
-		c, err := l.Accept()
-		if err != nil {
-			continue
-		}
-
-		go func(c net.Conn) {
-			w := bufio.NewWriter(c)
-			w.WriteString("+OK\r\n")
-			w.Flush()
-		}(c)
-	}
-}
-
-// TODO
-// Use qdb later
-func (s *testModelSuite) resetEnv() {
-	conn = zkhelper.NewConn()
-	once.Do(func() {
-		go s.runFakeRedisSrv("127.0.0.1:1111")
-		go s.runFakeRedisSrv("127.0.0.1:2222")
-		time.Sleep(1 * time.Second)
-	})
-}
-
 func (s *testModelSuite) TestAddSlaveToEmptyGroup(c *C) {
 	log.Info("[TestAddSlaveToEmptyGroup][start]")
-	s.resetEnv()
+	fakeCoordConn := zkhelper.NewConn()
 
 	g := NewServerGroup(productName, 1)
-	g.Create(conn)
+	g.Create(fakeCoordConn)
 
-	s1 := NewServer(SERVER_TYPE_SLAVE, "127.0.0.1:1111")
-	err := g.AddServer(conn, s1)
+	s1 := NewServer(SERVER_TYPE_SLAVE, s.s1.addr)
+	err := g.AddServer(fakeCoordConn, s1)
 	c.Assert(err, IsNil)
 	c.Assert(g.Servers[0].Type, Equals, SERVER_TYPE_MASTER)
 
+	fakeCoordConn.Close()
 	log.Info("[TestAddSlaveToEmptyGroup][end]")
 }
 
 func (s *testModelSuite) TestServerGroup(c *C) {
 	log.Info("[TestServerGroup][start]")
-	s.resetEnv()
+	fakeCoordConn := zkhelper.NewConn()
 
 	g := NewServerGroup(productName, 1)
-	g.Create(conn)
+	g.Create(fakeCoordConn)
 
 	// test create new group
-	groups, err := ServerGroups(conn, productName)
+	groups, err := ServerGroups(fakeCoordConn, productName)
 	c.Assert(err, IsNil)
 	c.Assert(len(groups), Not(Equals), 0)
 
-	ok, err := g.Exists(conn)
+	ok, err := g.Exists(fakeCoordConn)
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)
 
-	gg, err := GetGroup(conn, productName, 1)
+	gg, err := GetGroup(fakeCoordConn, productName, 1)
 	c.Assert(err, IsNil)
 	c.Assert(gg, NotNil)
 	c.Assert(gg.Id, Equals, g.Id)
 
-	s1 := NewServer(SERVER_TYPE_MASTER, "127.0.0.1:1111")
-	s2 := NewServer(SERVER_TYPE_MASTER, "127.0.0.1:2222")
+	s1 := NewServer(SERVER_TYPE_MASTER, s.s1.addr)
+	s2 := NewServer(SERVER_TYPE_MASTER, s.s2.addr)
 
-	err = g.AddServer(conn, s1)
+	err = g.AddServer(fakeCoordConn, s1)
 	c.Assert(err, IsNil)
 
-	servers, err := g.GetServers(conn)
+	servers, err := g.GetServers(fakeCoordConn)
 	c.Assert(err, IsNil)
 	c.Assert(len(servers), Equals, 1)
 
-	g.AddServer(conn, s2)
+	g.AddServer(fakeCoordConn, s2)
 	c.Assert(len(g.Servers), Equals, 1)
 
 	s2.Type = SERVER_TYPE_SLAVE
-	g.AddServer(conn, s2)
+	g.AddServer(fakeCoordConn, s2)
 	c.Assert(len(g.Servers), Equals, 2)
 
-	err = g.Promote(conn, s2.Addr)
+	err = g.Promote(fakeCoordConn, s2.Addr)
 	c.Assert(err, IsNil)
 
-	m, err := g.Master(conn)
+	m, err := g.Master(fakeCoordConn)
 	c.Assert(err, IsNil)
 	c.Assert(m.Addr, Equals, s2.Addr)
 
+	fakeCoordConn.Close()
 	log.Info("[TestServerGroup][stop]")
 }

--- a/pkg/proxy/parser/parser.go
+++ b/pkg/proxy/parser/parser.go
@@ -77,7 +77,7 @@ func Itoa(i int) []byte {
 	return []byte(strconv.Itoa(i))
 }
 
-//todo: overflow
+// Todo: overflow
 func Btoi(b []byte) (int, error) {
 	n := 0
 	sign := 1
@@ -179,12 +179,6 @@ func Parse(r *bufio.Reader) (*Resp, error) {
 	}
 
 	resp := &Resp{}
-	// if line[0] == '$' || line[0] == '*' {
-	// 	resp.Raw = make([]byte, 0, len(line)+64)
-	// } else {
-	// 	resp.Raw = make([]byte, 0, len(line))
-	// }
-
 	switch line[0] {
 	case '-', '+', ':', '*':
 		// we will store bulk string and telnet raw later separately
@@ -252,6 +246,7 @@ func Parse(r *bufio.Reader) (*Resp, error) {
 
 			resp.Multi = append(resp.Multi, &Resp{Type: BulkResp, Raw: b})
 		}
+
 		return resp, nil
 	}
 }
@@ -282,7 +277,7 @@ func ReadBulk(r *bufio.Reader, size int, raw *[]byte) error {
 		*raw = append(*raw, old...)
 	}
 
-	//avoid copy
+	// avoid copy
 	if _, err := io.ReadFull(r, (*raw)[n:n+size]); err != nil {
 		return err
 	}
@@ -378,5 +373,6 @@ func WriteCommand(w io.Writer, cmd string, args ...interface{}) error {
 	for _, arg := range args {
 		err = writeBulkArg(sw, formatCommandArg(arg))
 	}
+
 	return err
 }

--- a/pkg/proxy/parser/parser.go
+++ b/pkg/proxy/parser/parser.go
@@ -77,7 +77,7 @@ func Itoa(i int) []byte {
 	return []byte(strconv.Itoa(i))
 }
 
-// Todo: overflow
+// TODO: overflow
 func Btoi(b []byte) (int, error) {
 	n := 0
 	sign := 1

--- a/pkg/proxy/router/helper_test.go
+++ b/pkg/proxy/router/helper_test.go
@@ -7,97 +7,64 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"testing"
 	"time"
 
 	"github.com/reborndb/reborn/pkg/proxy/parser"
 
 	"github.com/juju/errors"
 	stats "github.com/ngaut/gostats"
+	. "gopkg.in/check.v1"
 )
 
 const (
-	simple_request = "*3\r\n$3\r\nSET\r\n$5\r\nmykey\r\n$8\r\nmy value\r\n"
+	simpleRequest = "*3\r\n$3\r\nSET\r\n$5\r\nmykey\r\n$8\r\nmy value\r\n"
 )
 
-func TestStringsContain(t *testing.T) {
-	s := []string{"abc", "bcd", "ab"}
-	if StringsContain(s, "a") {
-		t.Error("should not found")
-	}
-
-	if !StringsContain(s, "ab") {
-		t.Error("shoud found")
-	}
+func (s *testProxyRouterSuite) TestStringsContain(c *C) {
+	ss := []string{"abc", "bcd", "ab"}
+	c.Assert(StringsContain(ss, "a"), Equals, false)
+	c.Assert(StringsContain(ss, "ab"), Equals, true)
 }
 
-func TestAllowOp(t *testing.T) {
-	if allowOp("SLOTSMGRT") || allowOp("SLOTSMGRTONE") {
-		t.Error("should not allowed")
-	}
-
-	if !allowOp("SET") {
-		t.Error("should be allowed")
-	}
+func (s *testProxyRouterSuite) TestAllowOp(c *C) {
+	c.Assert(allowOp("SLOTSMGRT"), Equals, false)
+	c.Assert(allowOp("SLOTSMGRTONE"), Equals, false)
+	c.Assert(allowOp("SET"), Equals, true)
 }
 
-func TestIsMulOp(t *testing.T) {
-	if isMulOp("GET") {
-		t.Error("is not mulOp")
-	}
-
-	if !isMulOp("MGET") || !isMulOp("DEL") || !isMulOp("MSET") {
-		t.Error("should be mulOp")
-	}
+func (s *testProxyRouterSuite) TestIsMulOp(c *C) {
+	c.Assert(isMulOp("GET"), Equals, false)
+	c.Assert(isMulOp("MGET"), Equals, true)
+	c.Assert(isMulOp("MSET"), Equals, true)
+	c.Assert(isMulOp("DEL"), Equals, true)
 }
 
-func TestRecordResponseTime(t *testing.T) {
-	c := stats.NewCounters("test")
-	recordResponseTime(c, 1)
-	recordResponseTime(c, 5)
-	recordResponseTime(c, 10)
-	recordResponseTime(c, 50)
-	recordResponseTime(c, 200)
-	recordResponseTime(c, 1000)
-	recordResponseTime(c, 5000)
-	recordResponseTime(c, 8000)
-	recordResponseTime(c, 10000)
-	cnts := c.Counts()
-	if cnts["0-5ms"] != 1 {
-		t.Fail()
-	}
-	if cnts["5-10ms"] != 1 {
-		t.Fail()
-	}
-	if cnts["50-200ms"] != 1 {
-		t.Fail()
-	}
-	if cnts["200-1000ms"] != 1 {
-		t.Fail()
-	}
-	if cnts["1000-5000ms"] != 1 {
-		t.Fail()
-	}
-	if cnts["5000-10000ms"] != 2 {
-		t.Fail()
-	}
-	if cnts["10000ms+"] != 1 {
-		t.Fail()
-	}
+func (s *testProxyRouterSuite) TestRecordResponseTime(c *C) {
+	cc := stats.NewCounters("test")
+	recordResponseTime(cc, 1)
+	recordResponseTime(cc, 5)
+	recordResponseTime(cc, 10)
+	recordResponseTime(cc, 50)
+	recordResponseTime(cc, 200)
+	recordResponseTime(cc, 1000)
+	recordResponseTime(cc, 5000)
+	recordResponseTime(cc, 8000)
+	recordResponseTime(cc, 10000)
+	cnts := cc.Counts()
+
+	c.Assert(cnts["0-5ms"], Equals, int64(1))
+	c.Assert(cnts["5-10ms"], Equals, int64(1))
+	c.Assert(cnts["50-200ms"], Equals, int64(1))
+	c.Assert(cnts["200-1000ms"], Equals, int64(1))
+	c.Assert(cnts["1000-5000ms"], Equals, int64(1))
+	c.Assert(cnts["5000-10000ms"], Equals, int64(2))
+	c.Assert(cnts["10000ms+"], Equals, int64(1))
 }
 
-func TestValidSlot(t *testing.T) {
-	if validSlot(-1) {
-		t.Error("should be invalid")
-	}
-
-	if validSlot(1024) {
-		t.Error("should be invalid")
-	}
-
-	if !validSlot(0) {
-		t.Error("should be valid")
-	}
+func (s *testProxyRouterSuite) TestValidSlot(c *C) {
+	c.Assert(validSlot(-1), Equals, false)
+	c.Assert(validSlot(1024), Equals, false)
+	c.Assert(validSlot(0), Equals, true)
 }
 
 type fakeDeadlineReadWriter struct {
@@ -125,69 +92,51 @@ func (rw *fakeDeadlineReadWriter) Write(p []byte) (int, error) {
 	return rw.w.Write(p)
 }
 
-func TestForward(t *testing.T) {
-	client := &fakeDeadlineReadWriter{r: bufio.NewReader(bytes.NewBuffer([]byte(simple_request))),
+func (s *testProxyRouterSuite) TestForward(c *C) {
+	client := &fakeDeadlineReadWriter{r: bufio.NewReader(bytes.NewBuffer([]byte(simpleRequest))),
 		w: bufio.NewWriter(&bytes.Buffer{})}
-	redis := &fakeDeadlineReadWriter{r: bufio.NewReader(bytes.NewBuffer([]byte(simple_request))),
+	redis := &fakeDeadlineReadWriter{r: bufio.NewReader(bytes.NewBuffer([]byte(simpleRequest))),
 		w: bufio.NewWriter(&bytes.Buffer{})}
 
-	resp, err := parser.Parse(bufio.NewReader(bytes.NewBuffer([]byte(simple_request))))
-	if err != nil {
-		t.Error(err)
-	}
+	resp, err := parser.Parse(bufio.NewReader(bytes.NewBuffer([]byte(simpleRequest))))
+	c.Assert(err, IsNil)
 
 	_, clientErr := forward(client, redis, resp, 5)
-	if clientErr != nil {
-		t.Error(clientErr)
-	}
+	c.Assert(clientErr, IsNil)
 }
 
-func TestWrite2Client(t *testing.T) {
+func (s *testProxyRouterSuite) TestWrite2Client(c *C) {
 	var result bytes.Buffer
 	var input bytes.Buffer
 	_, clientErr := write2Client(bufio.NewReader(&input), &result)
-	if clientErr == nil {
-		t.Error("should be error")
-	}
+	c.Assert(clientErr, NotNil)
 
-	input.WriteString(simple_request)
+	input.WriteString(simpleRequest)
 	_, clientErr = write2Client(bufio.NewReader(&input), &result)
-	if clientErr != nil {
-		t.Error(clientErr)
-	}
+	c.Assert(clientErr, IsNil)
 
-	if string(result.Bytes()) != simple_request {
-		t.Error("not match")
-	}
+	c.Assert(string(result.Bytes()), Equals, simpleRequest)
 }
 
-func TestWrite2Redis(t *testing.T) {
+func (s *testProxyRouterSuite) TestWrite2Redis(c *C) {
 	var result bytes.Buffer
 	var input bytes.Buffer
-	input.WriteString(simple_request)
+	input.WriteString(simpleRequest)
 	resp, err := parser.Parse(bufio.NewReader(&input))
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
 
 	err = resp.WriteTo(&result)
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
 
-	if string(result.Bytes()) != simple_request {
-		t.Error("not match")
-	}
+	c.Assert(string(result.Bytes()), Equals, simpleRequest)
 }
 
-func TestGetOrginError(t *testing.T) {
+func (s *testProxyRouterSuite) TestGetOrginError(c *C) {
 	err := errors.Trace(io.EOF)
-	if GetOriginError(errors.Trace(err).(*errors.Err)).Error() != io.EOF.Error() {
-		t.Error("should be io.EOF")
-	}
+	c.Assert(GetOriginError(errors.Trace(err).(*errors.Err)).Error(), Equals, io.EOF.Error())
 }
 
-func TestHandleSpecCommand(t *testing.T) {
+func (s *testProxyRouterSuite) TestHandleSpecCommand(c *C) {
 	var tbl = map[string]string{
 		"PING":   "+PONG\r\n",
 		"QUIT":   string(OK_BYTES),
@@ -196,63 +145,41 @@ func TestHandleSpecCommand(t *testing.T) {
 
 	for k, v := range tbl {
 		resp, err := parser.Parse(bufio.NewReader(bytes.NewBufferString(k + string(parser.NEW_LINE))))
-		if err != nil {
-			t.Error(err)
-		}
+		c.Assert(err, IsNil)
 
 		_, keys, err := resp.GetOpKeys()
-		if err != nil {
-			t.Error(errors.ErrorStack(err))
-		}
+		c.Assert(err, IsNil)
 
 		result, _, _, err := handleSpecCommand(k, keys, 5)
-		if err != nil {
-			t.Error(err)
-		}
-
-		if string(result) != v {
-			t.Error("result not match", string(result))
-		}
+		c.Assert(err, IsNil)
+		c.Assert(string(result), Equals, v)
 	}
 
-	//"ECHO xxxx": "xxxx\r\n",
+	// "ECHO xxxx": "xxxx\r\n",
 	{
 		resp, err := parser.Parse(bufio.NewReader(bytes.NewBufferString("ECHO xxxx\r\n")))
-		if err != nil {
-			t.Error(errors.ErrorStack(err))
-		}
+		c.Assert(err, IsNil)
 
 		_, keys, _ := resp.GetOpKeys()
-
 		result, _, _, err := handleSpecCommand("ECHO", keys, 5)
-		if err != nil {
-			t.Error(errors.ErrorStack(err))
-		}
-
-		if string(result) != "$4\r\nxxxx\r\n" {
-			t.Error("result not match", string(result))
-		}
+		c.Assert(err, IsNil)
+		c.Assert(string(result), Equals, "$4\r\nxxxx\r\n")
 	}
 
-	//test empty key
+	// test empty key
 	{
 		resp, err := parser.Parse(bufio.NewReader(bytes.NewBufferString("ECHO\r\n")))
-		if err != nil {
-			t.Error(errors.ErrorStack(err))
-		}
+		c.Assert(err, IsNil)
 
 		_, keys, _ := resp.GetOpKeys()
 		_, shouldClose, _, err := handleSpecCommand("ECHO", keys, 5)
-		if !shouldClose {
-			t.Error(errors.ErrorStack(err))
-		}
+		c.Assert(shouldClose, Equals, true)
 	}
 
-	//test not specific command
+	// test not specific command
 	{
-		_, _, handled, err := handleSpecCommand("get", nil, 5)
-		if handled {
-			t.Error(errors.ErrorStack(err))
-		}
+		_, _, handled, err := handleSpecCommand("GET", nil, 5)
+		c.Assert(handled, Equals, false)
+		c.Assert(err, IsNil)
 	}
 }

--- a/pkg/proxy/router/mapper_test.go
+++ b/pkg/proxy/router/mapper_test.go
@@ -3,14 +3,14 @@
 
 package router
 
-import "testing"
+import (
+	. "gopkg.in/check.v1"
+)
 
-func TestMapKey2Slot(t *testing.T) {
+func (s *testProxyRouterSuite) TestMapKey2Slot(c *C) {
 	index := mapKey2Slot([]byte("xxx"))
 	table := []string{"123{xxx}abc", "{xxx}aa", "x{xxx}"}
 	for _, v := range table {
-		if index != mapKey2Slot([]byte(v)) {
-			t.Error("not match", v)
-		}
+		c.Assert(index, Equals, mapKey2Slot([]byte(v)))
 	}
 }

--- a/pkg/proxy/router/multioperator.go
+++ b/pkg/proxy/router/multioperator.go
@@ -188,7 +188,7 @@ func (oper *MultiOperator) msetResults(mop *MulOp) ([]byte, error) {
 
 func (oper *MultiOperator) mset(mop *MulOp) {
 	start := time.Now()
-	defer func() { //todo:extra function
+	defer func() { // TODO: extra function
 		if sec := time.Since(start).Seconds(); sec > 2 {
 			log.Warning("too long to do del", sec)
 		}
@@ -206,7 +206,7 @@ func (oper *MultiOperator) mset(mop *MulOp) {
 
 func (oper *MultiOperator) del(mop *MulOp) {
 	start := time.Now()
-	defer func() { //todo:extra function
+	defer func() { // TODO: extra function
 		if sec := time.Since(start).Seconds(); sec > 2 {
 			log.Warning("too long to do del", sec)
 		}

--- a/pkg/proxy/router/multioperator_test.go
+++ b/pkg/proxy/router/multioperator_test.go
@@ -5,18 +5,16 @@ package router
 
 import (
 	"strings"
-	"testing"
 
 	"github.com/alicebob/miniredis"
+	. "gopkg.in/check.v1"
 )
 
 var redisrv *miniredis.Miniredis
 
-func TestMgetResults(t *testing.T) {
+func (s *testProxyRouterSuite) TestMgetResults(c *C) {
 	redisrv, err := miniredis.Run()
-	if err != nil {
-		t.Fatal("can not run miniredis")
-	}
+	c.Assert(err, IsNil)
 	defer redisrv.Close()
 
 	moper := newMultiOperator(redisrv.Addr(), "")
@@ -27,37 +25,29 @@ func TestMgetResults(t *testing.T) {
 		op: "mget",
 		keys: [][]byte{[]byte("a"),
 			[]byte("b"), []byte("c"), []byte("x")}})
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
 
 	res := string(buf)
-	if !strings.Contains(res, "a") || !strings.Contains(res, "b") || !strings.Contains(res, "c") {
-		t.Error("not match", res)
-	}
+	c.Assert(strings.Contains(res, "a"), Equals, true)
+	c.Assert(strings.Contains(res, "b"), Equals, true)
+	c.Assert(strings.Contains(res, "c"), Equals, true)
 
 	buf, err = moper.mgetResults(&MulOp{
 		op: "mget",
 		keys: [][]byte{[]byte("x"),
 			[]byte("c"), []byte("x")}})
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
 
 	buf, err = moper.mgetResults(&MulOp{
 		op: "mget",
 		keys: [][]byte{[]byte("x"),
 			[]byte("y"), []byte("x")}})
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
 }
 
-func TestMsetResults(t *testing.T) {
+func (s *testProxyRouterSuite) TestMsetResults(c *C) {
 	redisrv, err := miniredis.Run()
-	if err != nil {
-		t.Fatal("can not run miniredis")
-	}
+	c.Assert(err, IsNil)
 	defer redisrv.Close()
 
 	// for mset x y z bad case test
@@ -66,20 +56,13 @@ func TestMsetResults(t *testing.T) {
 		op: "mset",
 		keys: [][]byte{[]byte("x"),
 			[]byte("y"), []byte("z")}})
-	if err != nil {
-		if !strings.Contains(err.Error(), "bad number of keys for mset command") {
-			t.Error(err)
-		}
-	} else {
-		t.Error("unkown error - should not get here")
-	}
+	c.Assert(err, NotNil)
+	c.Assert(strings.Contains(err.Error(), "bad number of keys for mset command"), Equals, true)
 }
 
-func TestDeltResults(t *testing.T) {
+func (s *testProxyRouterSuite) TestDeltResults(c *C) {
 	redisrv, err := miniredis.Run()
-	if err != nil {
-		t.Fatal("can not run miniredis")
-	}
+	c.Assert(err, IsNil)
 	defer redisrv.Close()
 
 	moper := newMultiOperator(redisrv.Addr(), "")
@@ -90,12 +73,8 @@ func TestDeltResults(t *testing.T) {
 		op: "del",
 		keys: [][]byte{[]byte("a"),
 			[]byte("b"), []byte("c")}})
-	if err != nil {
-		t.Error(err)
-	}
+	c.Assert(err, IsNil)
 
 	res := string(buf)
-	if !strings.Contains(res, "3") {
-		t.Error("not match", res)
-	}
+	c.Assert(strings.Contains(res, "3"), Equals, true)
 }

--- a/pkg/proxy/router/multioperator_test.go
+++ b/pkg/proxy/router/multioperator_test.go
@@ -9,8 +9,12 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+var (
+	auth = ""
+)
+
 func (s *testProxyRouterSuite) TestMgetResults(c *C) {
-	moper := newMultiOperator(s.s.addr, "")
+	moper := newMultiOperator(s.s.addr, auth)
 
 	var err error
 	err = s.s.store.Set(0, "a", "a")
@@ -49,7 +53,7 @@ func (s *testProxyRouterSuite) TestMgetResults(c *C) {
 
 func (s *testProxyRouterSuite) TestMsetResults(c *C) {
 	// for mset x y z bad case test
-	moper := newMultiOperator(s.s.addr, "")
+	moper := newMultiOperator(s.s.addr, auth)
 	_, err := moper.msetResults(&MulOp{
 		op: "mset",
 		keys: [][]byte{[]byte("x"),
@@ -62,7 +66,7 @@ func (s *testProxyRouterSuite) TestMsetResults(c *C) {
 }
 
 func (s *testProxyRouterSuite) TestDeltResults(c *C) {
-	moper := newMultiOperator(s.s.addr, "")
+	moper := newMultiOperator(s.s.addr, auth)
 
 	var err error
 	err = s.s.store.Set(0, "a", "a")

--- a/pkg/proxy/router/router.go
+++ b/pkg/proxy/router/router.go
@@ -85,7 +85,7 @@ func (s *Server) stopTaskRunners() {
 	}
 	wg.Wait()
 
-	//remove all
+	// remove all
 	for k, _ := range s.pipeConns {
 		delete(s.pipeConns, k)
 	}
@@ -123,9 +123,9 @@ func (s *Server) fillSlot(i int, force bool) {
 	log.Infof("fill slot %d, force %v, %+v", i, force, slot.dst)
 
 	if slot.slotInfo.State.Status == models.SLOT_STATUS_MIGRATE {
-		//get migrate src group and fill it
+		// get migrate src group and fill it
 		from, err := s.top.GetGroup(slot.slotInfo.State.MigrateStatus.From)
-		if err != nil { //todo: retry ?
+		if err != nil { // TODO: retry ?
 			log.Fatal(err)
 		}
 		slot.migrateFrom = group.NewGroup(*from)
@@ -189,7 +189,7 @@ func (s *Server) handleMigrateState(slotIndex int, keys ...[]byte) error {
 
 	redisReader := redisConn.BufioReader()
 
-	//handle migrate result
+	// handle migrate result
 	for i := 0; i < len(keys); i++ {
 		resp, err := parser.Parse(redisReader)
 		if err != nil {
@@ -227,7 +227,7 @@ func (s *Server) sendBack(c *session, op []byte, keys [][]byte, resp *parser.Res
 	}
 
 	resp, err := parser.Parse(bufio.NewReader(bytes.NewReader(result)))
-	//just send to backQ
+	// just send to backQ
 	c.backQ <- &PipelineResponse{ctx: pr, err: err, resp: resp}
 }
 
@@ -280,7 +280,7 @@ func (s *Server) redisTunnel(c *session) error {
 	}
 
 	if isMulOp(opstr) {
-		if !isTheSameSlot(keys) { //can not send to redis directly
+		if !isTheSameSlot(keys) { // can not send to redis directly
 			var result []byte
 			err := s.moper.handleMultiOp(opstr, keys, &result)
 			if err != nil {
@@ -293,7 +293,7 @@ func (s *Server) redisTunnel(c *session) error {
 
 	i := mapKey2Slot(k)
 
-	//pipeline
+	// pipeline
 	c.pipelineSeq++
 	pr := &PipelineRequest{
 		slotIdx: i,
@@ -331,9 +331,9 @@ func (s *Server) handleConn(c net.Conn) {
 
 	var err error
 	defer func() {
-		client.closeSignal.Wait() //waiting for writer goroutine
+		client.closeSignal.Wait() // waiting for writer goroutine
 
-		if err != nil { //todo: fix this ugly error check
+		if err != nil { // TODO: fix this ugly error check
 			if GetOriginError(err.(*errors.Err)).Error() != io.EOF.Error() {
 				log.Warningf("close connection %v, %v", client, errors.ErrorStack(err))
 			} else {
@@ -423,7 +423,7 @@ func (s *Server) responseAction(seq int64) {
 }
 
 func (s *Server) getProxyInfo() models.ProxyInfo {
-	//todo:send request to evtbus, and get response
+	// TODO: send request to evtbus, and get response
 	var pi = s.pi
 	return pi
 }
@@ -440,11 +440,11 @@ func (s *Server) getActionObject(seq int, target interface{}) {
 
 func (s *Server) checkAndDoTopoChange(seq int) bool {
 	act, err := s.top.GetActionWithSeq(int64(seq))
-	if err != nil { //todo: error is not "not exist"
+	if err != nil { // TODO: error is not "not exist"
 		log.Fatal(errors.ErrorStack(err), "action seq", seq)
 	}
 
-	if !needResponse(act.Receivers, s.pi) { //no need to response
+	if !needResponse(act.Receivers, s.pi) { // no need to response
 		return false
 	}
 
@@ -463,7 +463,7 @@ func (s *Server) checkAndDoTopoChange(seq int) bool {
 		s.getActionObject(seq, serverGroup)
 		s.OnGroupChange(serverGroup.Id)
 	case models.ACTION_TYPE_SERVER_GROUP_REMOVE:
-		//do not care
+		// do not care
 	case models.ACTION_TYPE_MULTI_SLOT_CHANGED:
 		param := &models.SlotMultiSetParam{}
 		s.getActionObject(seq, param)
@@ -504,12 +504,12 @@ func (s *Server) handleProxyCommand() {
 
 func (s *Server) processAction(e interface{}) {
 	if strings.Index(GetEventPath(e), models.GetProxyPath(s.top.ProductName)) == 0 {
-		//proxy event, should be order for me to suicide
+		// proxy event, should be order for me to suicide
 		s.handleProxyCommand()
 		return
 	}
 
-	//re-watch
+	// re-watch
 	nodes, err := s.top.WatchChildren(models.GetWatchActionPath(s.top.ProductName), s.evtbus)
 	if err != nil {
 		log.Fatal(errors.ErrorStack(err))
@@ -524,7 +524,7 @@ func (s *Server) processAction(e interface{}) {
 		return
 	}
 
-	//get last pos
+	// get last pos
 	index := -1
 	for i, seq := range seqs {
 		if s.lastActionSeq < seq {
@@ -569,7 +569,7 @@ func (s *Server) dispatch(r *PipelineRequest) (success bool) {
 
 	tr, ok := s.pipeConns[s.slots[r.slotIdx].dst.Master()]
 	if !ok {
-		//try recreate taskrunner
+		// try recreate taskrunner
 		if err := s.createTaskRunner(s.slots[r.slotIdx]); err != nil {
 			r.backQ <- &PipelineResponse{ctx: r, resp: nil, err: err}
 			return true
@@ -775,7 +775,7 @@ func NewServer(conf *Conf) *Server {
 
 	s.FillSlots()
 
-	//start event handler
+	// start event handler
 	go s.handleTopoEvent()
 	go s.dumpCounter()
 

--- a/pkg/proxy/router/topology/topology.go
+++ b/pkg/proxy/router/topology/topology.go
@@ -166,7 +166,7 @@ func (top *Topology) doWatch(evtch <-chan topo.Event, evtbus chan interface{}) {
 	//case topo.EventNodeCreated:
 	//case topo.EventNodeDataChanged:
 	case topo.EventNodeChildrenChanged: //only care children changed
-		//todo:get changed node and decode event
+		//TODO: get changed node and decode event
 	default:
 		log.Warningf("%+v", e)
 	}

--- a/pkg/utils/redis_utils_test.go
+++ b/pkg/utils/redis_utils_test.go
@@ -2,25 +2,3 @@
 // Licensed under the MIT (MIT-LICENSE.txt) license.
 
 package utils
-
-/*
-const (
-	redisAddr = ":6379"
-)
-
-func TestSlotSize(t *testing.T) {
-	c, _ := redis.Dial("tcp", redisAddr)
-	defer c.Close()
-
-	ret, err := SlotsInfo(redisAddr, 1023, 0)
-	log.Info(len(ret))
-
-	if err == nil {
-		t.Error("should be error")
-	}
-}
-
-func TestStat(t *testing.T) {
-	log.Info(GetRedisStat(redisAddr))
-}
-*/


### PR DESCRIPTION
Completed qdb support, no miniredis.
But a test case not passed, maybe because reborn use pipeline and some problem when processing close connection.
We should see it later.