### PR TITLE
use simple list for conn pool

### DIFF
--- a/pkg/proxy/redisconn/pool.go
+++ b/pkg/proxy/redisconn/pool.go
@@ -131,6 +131,17 @@ func (p *Pools) PutConn(c *Conn) {
 	}
 }
 
+func (p *Pools) ClearPool(addr string) {
+	p.m.Lock()
+	pool, ok := p.mpools[addr]
+	p.m.Unlock()
+	if !ok {
+		return
+	}
+
+	pool.Clear()
+}
+
 func (p *Pools) Clear() {
 	p.m.Lock()
 	defer p.m.Unlock()

--- a/pkg/proxy/redisconn/pool.go
+++ b/pkg/proxy/redisconn/pool.go
@@ -75,7 +75,7 @@ func (p *Pool) PutConn(c *Conn) {
 	p.conns.PushBack(&poolConn{c, time.Now()})
 }
 
-func (p *Pool) Close() {
+func (p *Pool) Clear() {
 	p.m.Lock()
 	defer p.m.Unlock()
 
@@ -131,16 +131,12 @@ func (p *Pools) PutConn(c *Conn) {
 	}
 }
 
-func (p *Pools) Close() {
-	p.Clear()
-}
-
 func (p *Pools) Clear() {
 	p.m.Lock()
 	defer p.m.Unlock()
 
 	for _, pool := range p.mpools {
-		pool.Close()
+		pool.Clear()
 	}
 
 	p.mpools = map[string]*Pool{}

--- a/pkg/proxy/redisconn/pool.go
+++ b/pkg/proxy/redisconn/pool.go
@@ -4,40 +4,58 @@
 package redisconn
 
 import (
+	"container/list"
 	"sync"
 	"time"
-
-	"github.com/juju/errors"
-	"github.com/ngaut/pools"
 )
 
 const PoolIdleTimeoutSecond = 120
 
 type CreateConnFunc func(addr string) (*Conn, error)
 
+type poolConn struct {
+	c    *Conn
+	last time.Time
+}
+
 type Pool struct {
-	p *pools.ResourcePool
+	m sync.Mutex
+
+	f          CreateConnFunc
+	addr       string
+	capability int
+	conns      *list.List
 }
 
 func NewPool(addr string, capability int, f CreateConnFunc) *Pool {
-	poolFunc := func() (pools.Resource, error) {
-		return f(addr)
-	}
-
 	p := new(Pool)
-	p.p = pools.NewResourcePool(poolFunc, capability, capability, PoolIdleTimeoutSecond*time.Second)
+	p.f = f
+	p.addr = addr
+	p.capability = capability
+
+	p.conns = list.New()
+
 	return p
 }
 
 func (p *Pool) GetConn() (*Conn, error) {
-	conn, err := p.p.Get()
-	if err != nil {
-		return nil, errors.Trace(err)
-	} else if conn == nil {
-		return nil, errors.Errorf("create nil connection")
-	} else {
-		return conn.(*Conn), nil
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	n := time.Now()
+	for p.conns.Len() > 0 {
+		e := p.conns.Front()
+		p.conns.Remove(e)
+
+		c := e.Value.(*poolConn)
+		if n.Sub(c.last) > time.Duration(PoolIdleTimeoutSecond)*time.Second {
+			c.c.Close()
+		} else {
+			return c.c, nil
+		}
 	}
+
+	return p.f(p.addr)
 }
 
 func (p *Pool) PutConn(c *Conn) {
@@ -45,11 +63,27 @@ func (p *Pool) PutConn(c *Conn) {
 		return
 	}
 
-	p.p.Put(c)
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for p.conns.Len() >= p.capability {
+		e := p.conns.Front()
+		p.conns.Remove(e)
+		e.Value.(*poolConn).c.Close()
+	}
+
+	p.conns.PushBack(&poolConn{c, time.Now()})
 }
 
 func (p *Pool) Close() {
-	p.p.Close()
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for p.conns.Len() > 0 {
+		e := p.conns.Front()
+		p.conns.Remove(e)
+		e.Value.(*poolConn).c.Close()
+	}
 }
 
 type Pools struct {
@@ -98,6 +132,10 @@ func (p *Pools) PutConn(c *Conn) {
 }
 
 func (p *Pools) Close() {
+	p.Clear()
+}
+
+func (p *Pools) Clear() {
 	p.m.Lock()
 	defer p.m.Unlock()
 

--- a/pkg/proxy/redisconn/pool_test.go
+++ b/pkg/proxy/redisconn/pool_test.go
@@ -60,6 +60,6 @@ func (s *testPoolSuite) TestPool(c *C) {
 
 	c.Assert(p.conns.Len(), Equals, capability-1)
 
-	p.Close()
+	p.Clear()
 	c.Assert(p.conns.Len(), Equals, 0)
 }

--- a/pkg/proxy/redisconn/pool_test.go
+++ b/pkg/proxy/redisconn/pool_test.go
@@ -1,0 +1,65 @@
+// Copyright 2015 Reborndb Org. All Rights Reserved.
+// Licensed under the MIT (MIT-LICENSE.txt) license.
+
+package redisconn
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+type testPoolSuite struct {
+}
+
+var _ = Suite(&testPoolSuite{})
+
+type testDummyConn struct {
+}
+
+func (c *testDummyConn) Read(b []byte) (n int, err error)   { return len(b), nil }
+func (c *testDummyConn) Write(b []byte) (n int, err error)  { return len(b), nil }
+func (c *testDummyConn) Close() error                       { return nil }
+func (c *testDummyConn) LocalAddr() net.Addr                { return nil }
+func (c *testDummyConn) RemoteAddr() net.Addr               { return nil }
+func (c *testDummyConn) SetDeadline(t time.Time) error      { return nil }
+func (c *testDummyConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *testDummyConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func (s *testPoolSuite) TestPool(c *C) {
+	f := func(addr string) (*Conn, error) {
+		return &Conn{closed: false, nc: &testDummyConn{}}, nil
+	}
+
+	capability := 4
+	p := NewPool("127.0.0.1:6379", 4, f)
+
+	conns := make([]*Conn, 0, capability+2)
+	for i := 0; i < capability+2; i++ {
+		conn, err := p.GetConn()
+		c.Assert(err, IsNil)
+		conns = append(conns, conn)
+	}
+
+	for i := 0; i < len(conns); i++ {
+		p.PutConn(conns[i])
+	}
+
+	c.Assert(p.conns.Len(), Equals, capability)
+
+	conn, err := p.GetConn()
+	c.Assert(err, IsNil)
+	conn.Close()
+	p.PutConn(conn)
+
+	c.Assert(p.conns.Len(), Equals, capability-1)
+
+	p.Close()
+	c.Assert(p.conns.Len(), Equals, 0)
+}


### PR DESCRIPTION
Old pool resource may hangout when closing if we don’t use it
correctly. This may be a risk.