### PR TITLE
fix redis config MAXMEMORY to lowercase

### DIFF
--- a/cmd/cconfig/rebalancer.go
+++ b/cmd/cconfig/rebalancer.go
@@ -42,7 +42,7 @@ func getLivingNodeInfos(coordConn zkhelper.Conn) ([]*NodeInfo, error) {
 		if master == nil {
 			return nil, errors.Errorf("group %d has no master", g.Id)
 		}
-		out, err := utils.GetRedisConfig(master.Addr, "MAXMEMORY", globalEnv.StoreAuth())
+		out, err := utils.GetRedisConfig(master.Addr, "maxmemory", globalEnv.StoreAuth())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
In auto-rebalance process, get null for config "MAXMEMORY", which will cause paserInt error, then rebalance process stop for the error. The correct config is lowercase 'maxmemory'