### PR TITLE
when auth fails, the connection is immediately turned off before send back

### DIFF
--- a/pkg/proxy/router/router.go
+++ b/pkg/proxy/router/router.go
@@ -233,7 +233,7 @@ func (s *Server) sendBack(c *session, op []byte, keys [][]byte, resp *parser.Res
 
 func (s *Server) handleAuthCommand(opstr string, auth []byte) ([]byte, error) {
 	if string(auth) != s.conf.ProxyAuth {
-		return []byte("-ERR invalid auth"), errors.Errorf("invalid auth")
+		return []byte("-ERR invalid auth\r\n"), errors.Errorf("invalid auth")
 	}
 
 	return OK_BYTES, nil
@@ -254,7 +254,7 @@ func (s *Server) redisTunnel(c *session) error {
 		c.authenticated = (err == nil)
 		return errors.Trace(err)
 	} else if len(s.conf.ProxyAuth) > 0 && !c.authenticated {
-		buf := []byte("-ERR NOAUTH Authentication required")
+		buf := []byte("-ERR NOAUTH Authentication required\r\n")
 		s.sendBack(c, op, keys, resp, buf)
 		return errors.Errorf("NOAUTH Authentication required")
 	}

--- a/pkg/proxy/router/router_test.go
+++ b/pkg/proxy/router/router_test.go
@@ -229,6 +229,20 @@ func (s *testProxyRouterSuite) testDialConn(c *C, addr string, auth string) redi
 	return cc
 }
 
+func (s *testProxyRouterSuite) TestAuthCmd(c *C) {
+	cc, err := redis.Dial("tcp", proxyAddr)
+	c.Assert(err, IsNil)
+
+	ok, err := redis.String(cc.Do("AUTH", proxyAuth))
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, "OK")
+
+	ok, err = redis.String(cc.Do("AUTH", "Wrong-auth-key"))
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, "ERR invalid auth")
+	c.Assert(ok, Equals, "")
+}
+
 func (s *testProxyRouterSuite) TestSingleKeyRedisCmd(c *C) {
 	cc := s.testDialConn(c, proxyAddr, proxyAuth)
 	defer cc.Close()


### PR DESCRIPTION
the response buf miss "\r\n"

redis client can not receive any tips when auth fail